### PR TITLE
Feature/output interval att

### DIFF
--- a/src/core_atmosphere/diagnostics/Registry_convective.xml
+++ b/src/core_atmosphere/diagnostics/Registry_convective.xml
@@ -117,5 +117,15 @@
 
         <var name="v10m_mean"  type="real"     dimensions="nCells Time" units="m s^{-1}"
              description="Mean 10 m meridional wind speed since last output"/>
+
+	<var name="prec_acc_nc"  type="real"   dimensions="nCells Time" units="mm"
+	     description="Accumulated grid scale precipitation over prec_acc_dt periods of time"/>
+
+	<var name="prec_acc_c"  type="real"   dimensions="nCells Time" units="mm"
+	    description="Accumulated cumulus precipitation over prec_acc_dt periods of time"/>
+
+	<var name="snow_acc_nc"  type="real"  dimensions="nCells Time"  units="mm"
+	    description="Accumulated snow water equivalent over prec_acc_dt periods of time"/>
+
 </var_struct>
 

--- a/src/core_atmosphere/diagnostics/convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/convective_diagnostics.F
@@ -360,7 +360,7 @@ module convective_diagnostics
         call mpas_get_timeInterval(diag_interval, ref_time, S=diag_tmp)
         
         call mpas_interval_division(ref_time, diag_interval, dt_interval, nsteps, extra)
-        print*, dt_tmp, diag_tmp, nsteps
+        
         if (do_any_diags) then
             call mpas_pool_get_dimension(mesh, 'nCells', nCells)
             call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)

--- a/src/core_atmosphere/diagnostics/convective_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/convective_diagnostics.F
@@ -55,6 +55,9 @@ module convective_diagnostics
     logical :: is_needed_lml_wsp_max
     logical :: is_needed_wind02_max
     logical :: is_needed_wind02_integral_max
+    logical :: is_needed_prec_acc_c
+    logical :: is_needed_prec_acc_nc
+    logical :: is_needed_snow_acc_nc
     logical :: do_any_uh, do_any_diags 
 
     contains
@@ -115,6 +118,9 @@ module convective_diagnostics
         is_needed_lml_wsp_max = .false.
         is_needed_wind02_max  = .false.
         is_needed_wind02_integral_max = .false.
+        is_needed_prec_acc_c = .false.
+        is_needed_prec_acc_nc = .false.
+        is_needed_snow_acc_nc = .false.
         do_any_uh = .false.
         do_any_diags = .false.
         ! - UH Variables
@@ -215,7 +221,22 @@ module convective_diagnostics
          if (mpas_stream_inclusion_count('w_velocity_mean', direction=MPAS_STREAM_OUTPUT) > 0) then
             is_needed_w_mean = .true.
         end if
-        do_any_diags = do_any_diags .or. is_needed_w_mean
+
+        ! - Precipitation accumulation
+        if (mpas_stream_inclusion_count('prec_acc_c', direction=MPAS_STREAM_OUTPUT) > 0) then
+            is_needed_prec_acc_c = .true.
+        endif
+        do_any_diags = do_any_diags .or. is_needed_prec_acc_c
+
+        if (mpas_stream_inclusion_count('prec_acc_nc', direction=MPAS_STREAM_OUTPUT) > 0) then
+            is_needed_prec_acc_nc = .true.
+        endif
+        do_any_diags = do_any_diags .or. is_needed_prec_acc_nc
+
+        if (mpas_stream_inclusion_count('snow_acc_nc', direction=MPAS_STREAM_OUTPUT) > 0) then
+            is_needed_snow_acc_nc = .true.
+        endif
+        do_any_diags = do_any_diags .or. is_needed_snow_acc_nc
 
 
         ! - Horizontal wind speed
@@ -321,8 +342,10 @@ module convective_diagnostics
         real (kind=RKIND), dimension(:), pointer :: updraft_helicity_min_03
         real (kind=RKIND), dimension(:,:), pointer :: uzonal, umeridional
         real (kind=RKIND), dimension(:,:), pointer :: pressure_base, pressure_p
-        real (kind=RKIND), dimension(:), pointer :: u10m, v10m
+        real (kind=RKIND), dimension(:), pointer :: u10m, v10m, t2m
         real (kind=RKIND), dimension(:,:), pointer :: refl10cm
+        real (kind=RKIND), dimension(:), pointer :: rainncv, snowncv, graupelncv
+        real (kind=RKIND), dimension(:), pointer :: prec_acc_c, prec_acc_nc, snow_acc_nc
         real (kind=RKIND) :: uph, pb, pt
 
         type (MPAS_timeinterval_type) :: dt_interval, diag_interval, extra
@@ -337,6 +360,7 @@ module convective_diagnostics
         call mpas_get_timeInterval(diag_interval, ref_time, S=diag_tmp)
         
         call mpas_interval_division(ref_time, diag_interval, dt_interval, nsteps, extra)
+        print*, dt_tmp, diag_tmp, nsteps
         if (do_any_diags) then
             call mpas_pool_get_dimension(mesh, 'nCells', nCells)
             call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
@@ -378,8 +402,16 @@ module convective_diagnostics
             call mpas_pool_get_array(diag_physics, 'refl10cm', refl10cm)
             call mpas_pool_get_array(diag_physics, 'u10', u10m)
             call mpas_pool_get_array(diag_physics, 'v10', v10m)
+            call mpas_pool_get_array(diag_physics, 't2m', t2m)
+            call mpas_pool_get_array(diag_physics, 'rainncv', rainncv)
+            call mpas_pool_get_array(diag_physics, 'snowncv', snowncv)
+            call mpas_pool_get_array(diag_physics, 'graupelncv', graupelncv)
+
             call mpas_pool_get_array(diag, 'pressure_base', pressure_base)
             call mpas_pool_get_array(diag, 'pressure_p', pressure_p)
+            call mpas_pool_get_array(diag, 'prec_acc_c', prec_acc_c)
+            call mpas_pool_get_array(diag, 'prec_acc_nc', prec_acc_nc)
+            call mpas_pool_get_array(diag, 'snow_acc_nc', snow_acc_nc)
 
             call mpas_pool_get_array(state, 'w', w, 1)
 
@@ -467,6 +499,27 @@ module convective_diagnostics
                   wind_speed_level1_max(iCell) = max(wind_speed_level1_max(iCell), sqrt(uzonal(1,iCell)**2+umeridional(1,iCell)**2))
                 end do
             end if
+
+            if (is_needed_prec_acc_c .or. is_needed_prec_acc_nc .or. is_needed_snow_acc_nc) then
+                do iCell=1, nCellsSolve
+                    if (is_needed_prec_acc_c) then
+                        prec_acc_c(iCell)  = prec_acc_c(iCell)  +  rainncv(iCell)
+                        prec_acc_c(iCell)  = MAX (prec_acc_c(iCell), 0.0)
+                    endif
+                    if (is_needed_prec_acc_nc) then
+                        prec_acc_nc(iCell) = prec_acc_nc(iCell) + rainncv(iCell)
+                        prec_acc_nc(iCell) = MAX (prec_acc_nc(iCell), 0.0)
+                    endif
+                    if (is_needed_snow_acc_nc) then
+                        snow_acc_nc(iCell)   = snow_acc_nc(iCell) + snowncv(iCell)
+               ! add convective precip to snow bucket if t2m < 273.15
+                        IF ( t2m(iCell) .lt. 273.15 ) THEN
+                          snow_acc_nc(iCell)   = snow_acc_nc(iCell) +  rainncv(iCell)
+                          snow_acc_nc(iCell)   = MAX (snow_acc_nc(iCell), 0.0)
+                        ENDIF
+                    endif
+                enddo
+            endif
 
             if (do_any_uh) then
                 allocate(updraft_helicity(nVertLevels,nCells+1))
@@ -889,6 +942,7 @@ module convective_diagnostics
         real (kind=RKIND), dimension(:), pointer :: updraft_helicity_min05_15
         real (kind=RKIND), dimension(:), pointer :: updraft_helicity_min_02
         real (kind=RKIND), dimension(:), pointer :: updraft_helicity_min_03
+        real (kind=RKIND), dimension(:), pointer :: prec_acc_c, prec_acc_nc, snow_acc_nc
 
         if (MPAS_field_will_be_written('updraft_helicity_max')) then
             call mpas_pool_get_array(diag, 'updraft_helicity_max', updraft_helicity_max)
@@ -986,6 +1040,18 @@ module convective_diagnostics
             call mpas_pool_get_array(diag, 'v10m_mean', v10m_mean)
             v10m_mean(:) = 0.
         end if
+        if (MPAS_field_will_be_written('prec_acc_nc')) then
+            call mpas_pool_get_array(diag, 'prec_acc_nc', prec_acc_nc)
+            prec_acc_nc(:) = 0.
+        endif
+         if (MPAS_field_will_be_written('prec_acc_c')) then
+            call mpas_pool_get_array(diag, 'prec_acc_c', prec_acc_c)
+            prec_acc_c(:) = 0.
+        endif
+         if (MPAS_field_will_be_written('snow_acc_nc')) then
+            call mpas_pool_get_array(diag, 'snow_acc_nc', snow_acc_nc)
+            snow_acc_nc(:) = 0.
+        endif
 
     end subroutine convective_diagnostics_reset
 

--- a/src/framework/mpas_io_streams.F
+++ b/src/framework/mpas_io_streams.F
@@ -183,7 +183,6 @@ module mpas_io_streams
 
       if (present(maxRecords)) maxRecords = timeDim
 
-call mpas_log_write('Found $i times in file', intArgs=(/timeDim/))
 
       call MPAS_io_inq_var(stream % fileHandle, 'xtime', ierr=io_err)
       if (io_err /= MPAS_IO_NOERR) then
@@ -192,7 +191,6 @@ call mpas_log_write('Found $i times in file', intArgs=(/timeDim/))
          return
       end if
 
-call mpas_log_write('Found xtime variable')
 
       ! the following section of code improves performance for forcing files
       ! that have large numbers of evenly spaced times by reducing the number
@@ -253,7 +251,6 @@ call mpas_log_write('Found xtime variable')
       do i=1,timeDim
          call MPAS_io_set_frame(stream % fileHandle, i, io_err)
          call MPAS_io_get_var(stream % fileHandle, 'xtime', xtimes(i), io_err)
-call mpas_log_write('... just read in xtime='//xtimes(i))
       end do
 
       if (len(seekTime) > 32) then
@@ -268,7 +265,6 @@ call mpas_log_write('... just read in xtime='//xtimes(i))
 
       do i=1,timeDim
          write(strTemp, '(a)') trim(xtimes(i)(1:32))
-call mpas_log_write('... converted strTemp='//trim(xtimes(i)(1:32)))
          call mpas_set_time(curr_time=sliceTime, dateTimeString=strTemp)
          if (seekPosition == MPAS_STREAM_EXACT_TIME) then
             if (sliceTime == startTime) then

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -4223,7 +4223,8 @@ module mpas_stream_manager
         character (len=StrKIND), pointer :: packages
         logical :: active_field
         integer :: err_level
-
+        integer :: output_interval
+        type (MPAS_timeInterval_type) :: filename_interval
 
         if (direction == MPAS_STREAM_OUTPUT) then
 
@@ -4264,6 +4265,17 @@ module mpas_stream_manager
             call gen_random(idLength, c_file_id)
             call mpas_c_to_f_string(c_file_id, f_file_id)
             call mpas_writeStreamAtt(stream % stream, 'file_id', f_file_id, syncVal=.true., ierr=local_ierr)
+            if (local_ierr /= MPAS_STREAM_NOERR) then
+                ierr = MPAS_STREAM_MGR_ERROR
+                return
+            end if
+
+            !
+            ! Write output_interval to stream
+            !
+            call mpas_set_timeInterval(filename_interval, timeString=stream %filename_interval)
+            call mpas_get_timeInterval(filename_interval,M=output_interval)
+            call mpas_writeStreamAtt(stream%stream, 'output_interval',output_interval,syncVal=.true., ierr=local_ierr)
             if (local_ierr /= MPAS_STREAM_NOERR) then
                 ierr = MPAS_STREAM_MGR_ERROR
                 return


### PR DESCRIPTION
Changes to include each stream's output_interval (as defined in the streams list at runtime) as a global attribute in the output files. This value from the diag file is used in MPASSIT as a stand-in for WRF's PREC_ACC_DT.

