### PR TITLE
Radiation NSSLmp fix

### DIFF
--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_lw.F
@@ -416,7 +416,7 @@
 
     case("rrtmg_lw")
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_wsm6","mp_nssl2m")
              if(config_microp_re) then
                 call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
                 call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )
@@ -688,7 +688,7 @@
     case("rrtmg_lw")
 
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_wsm6","mp_nssl2m")
              call mpas_pool_get_array(diag_physics,'rre_cloud',rre_cloud)
              call mpas_pool_get_array(diag_physics,'rre_ice'  ,rre_ice  )
              call mpas_pool_get_array(diag_physics,'rre_snow' ,rre_snow )

--- a/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_driver_radiation_sw.F
@@ -414,7 +414,7 @@
     case("rrtmg_sw")
 
        microp_select: select case(microp_scheme)
-          case("mp_thompson","mp_wsm6")
+          case("mp_thompson","mp_wsm6","mp_nssl2m")
              if(config_microp_re) then
                 call mpas_pool_get_array(diag_physics,'re_cloud',re_cloud)
                 call mpas_pool_get_array(diag_physics,'re_ice'  ,re_ice  )


### PR DESCRIPTION
Radiation drivers were not using effective radii from NSSLmp because it wasn't added to the case statement.